### PR TITLE
More supported characters feature

### DIFF
--- a/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,9 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        //change stringlength to 250 and update error message
+
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion

--- a/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        //change stringlength to 250 and update error message
+        //Resolves #3
 
         [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }


### PR DESCRIPTION
This pull request to the `Application` project in the `src/RazorPagesTestSample` directory updates the `Text` property in the `Message` class to allow a maximum of 250 characters instead of 200.

* <a href="diffhunk://#diff-3a68b54c333d01e48727b3f767c1155f37920ee7e4b2bcc8fd5c0cda0debce19L12-R14">`Application/src/RazorPagesTestSample/Data/Message.cs`</a>: Updated the `Text` property in the `Message` class to allow a maximum of 250 characters.